### PR TITLE
Add SMTP Mailing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+DATABASE_URL="postgresql://user:password@host:port/dbname"
+
+# Mail Service, options are gmail and smtp
+MAIL_SERVICE=smtp
+
+# SMTP Configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_username@example.com
+SMTP_PASS=your_strong_password_here
+
+# Sender Information
+SMTP_FROM_NAME="Dungeon Club"
+SMTP_FROM_EMAIL=noreply@dungeonclub.com

--- a/src/lib/logic/server/server.ts
+++ b/src/lib/logic/server/server.ts
@@ -7,6 +7,7 @@ import { GmailMailService } from './services/mail/service-gmail';
 import { SessionManager } from './session';
 import { ConnectionSocket } from './socket';
 import { getWebSocketServer } from './ws-server/ws-server';
+import {SMTPMailService} from "./services/mail/service-smtp";
 
 export { prisma };
 
@@ -16,10 +17,24 @@ export class Server {
 	readonly sessionManager = new SessionManager();
 	readonly webSocketManager = new WebSocketManager();
 
-	readonly mailService: MailService = new GmailMailService();
+	readonly mailService: MailService;
 
 	async start() {
 		this.webSocketManager.start();
+	}
+
+	constructor() {
+		switch (process.env.MAIL_SERVICE) {
+			case 'gmail':
+				this.mailService = new GmailMailService();
+				break;
+			case 'smtp':
+				this.mailService = new SMTPMailService();
+				break;
+			default:
+				// TODO: Add a warning here, but then default to the Dummy mailer from the other PR
+				throw new Error('Unsupported mail service');
+		}
 	}
 }
 

--- a/src/lib/logic/server/services/mail/service-smtp.ts
+++ b/src/lib/logic/server/services/mail/service-smtp.ts
@@ -1,0 +1,61 @@
+import {
+	SMTP_HOST,
+	SMTP_PORT,
+	SMTP_SECURE,
+	SMTP_USER,
+	SMTP_PASS,
+	SMTP_FROM_NAME,
+	SMTP_FROM_EMAIL
+} from '$env/static/private';
+import nodemailer, { type Transporter } from 'nodemailer';
+import { MailService, type SendMailOptions } from '../mail-service';
+
+export class SMTPMailService extends MailService {
+	private transporter: Transporter | null = null;
+
+	constructor() {
+		super();
+		this.setupTransporter();
+	}
+
+	private setupTransporter() {
+		try {
+			this.transporter = nodemailer.createTransport({
+				host: SMTP_HOST,
+				port: parseInt(SMTP_PORT),
+				secure: SMTP_SECURE === 'true',
+				auth: {
+					user: SMTP_USER,
+					pass: SMTP_PASS
+				}
+			});
+		} catch (err) {
+			console.error('Failed to setup SMTP mailing service');
+			console.error(err);
+		}
+	}
+
+	async sendMail(options: SendMailOptions): Promise<void> {
+		const client = this.transporter;
+
+		if (!client) {
+			throw 'Transporter not initialized';
+		}
+
+		const result = await client.sendMail({
+			subject: options.subject,
+			from: { name: SMTP_FROM_NAME, address: SMTP_FROM_EMAIL },
+			to: options.recipient,
+			html: options.htmlBody,
+			attachments: [
+				{
+					cid: 'logo',
+					filename: 'logo.png',
+					content: await MailService.loadLogoImage()
+				}
+			]
+		});
+
+		console.log('Result after sending mail:', result);
+	}
+}


### PR DESCRIPTION
Add the ability to configure SMTP mail driver using set credentials. Tested with postmark and working fine. Mail service is set on env level as well. Gmail service is still available.

Once the other PR is merged there will be a conflict but I can resolve that. We want to default to the dummy mail log if no mail service is configured.